### PR TITLE
修复226题单元测试的问题

### DIFF
--- a/leetcode/0226.Invert-Binary-Tree/226. Invert Binary Tree_test.go
+++ b/leetcode/0226.Invert-Binary-Tree/226. Invert Binary Tree_test.go
@@ -50,7 +50,7 @@ func Test_Problem226(t *testing.T) {
 		_, p := q.ans226, q.para226
 		fmt.Printf("【input】:%v      ", p)
 		root := structures.Ints2TreeNode(p.one)
-		fmt.Printf("【output】:%v      \n", structures.Tree2Preorder(invertTree(root)))
+		fmt.Printf("【output】:%v      \n", structures.Tree2ints(invertTree(root)))
 	}
 	fmt.Printf("\n\n\n")
 }


### PR DESCRIPTION
将TreeNode转换成slice的时候，应该使用 `structures.Tree2ints` 按行还原，而不应该使用 `structures.Tree2Preorder`，否则问题中的例子会输出 `[4 7 9 6 2 3 1]`，而不是`[4 7 2 9 6 3 1]`。