### PR TITLE
Fixed display problems of uint32 type during go test

### DIFF
--- a/leetcode/0190.Reverse-Bits/190. Reverse Bits_test.go
+++ b/leetcode/0190.Reverse-Bits/190. Reverse Bits_test.go
@@ -2,6 +2,7 @@ package leetcode
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -23,7 +24,6 @@ type ans190 struct {
 }
 
 func Test_Problem190(t *testing.T) {
-
 	qs := []question190{
 
 		{
@@ -41,7 +41,12 @@ func Test_Problem190(t *testing.T) {
 
 	for _, q := range qs {
 		_, p := q.ans190, q.para190
-		fmt.Printf("【input】:%v       【output】:%v\n", p, reverseBits(p.one))
+		input := strconv.FormatUint(uint64(p.one), 2) // 32位无符号整数转换为二进制字符串
+		input = fmt.Sprintf("%0*v", 32, input)        // 格式化输出32位,保留前置0
+		output := reverseBits(p.one)
+		outputBin := strconv.FormatUint(uint64(output), 2) // 32位无符号整数转换为二进制字符串
+		outputBin = fmt.Sprintf("%0*v", 32, outputBin)     // 格式化输出32位,保留前置0
+		fmt.Printf("【input】:%v       【output】:%v (%v)\n", input, output, outputBin)
 	}
 	fmt.Printf("\n\n\n")
 }

--- a/leetcode/0191.Number-of-1-Bits/191. Number of 1 Bits_test.go
+++ b/leetcode/0191.Number-of-1-Bits/191. Number of 1 Bits_test.go
@@ -2,6 +2,7 @@ package leetcode
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -40,7 +41,9 @@ func Test_Problem191(t *testing.T) {
 
 	for _, q := range qs {
 		_, p := q.ans191, q.para191
-		fmt.Printf("【input】:%v       【output】:%v\n", p, hammingWeight(p.one))
+		input := strconv.FormatUint(uint64(p.one), 2) // 32位无符号整数转换为二进制字符串
+		input = fmt.Sprintf("%0*v", 32, input)        // 格式化输出32位,保留前置0
+		fmt.Printf("【input】:%v       【output】:%v\n", input, hammingWeight(p.one))
 	}
 	fmt.Printf("\n\n\n")
 }


### PR DESCRIPTION
修复了题目190和191运行go test时，uint32类型的显示问题。
```go
for _, q := range qs {
      _, p := q.ans190, q.para190
      input := strconv.FormatUint(uint64(p.one), 2) // 32位无符号整数转换为二进制字符串
      input = fmt.Sprintf("%0*v", 32, input)        // 格式化输出32位,保留前置0
      output := reverseBits(p.one)
      outputBin := strconv.FormatUint(uint64(output), 2) // 32位无符号整数转换为二进制字符串
      outputBin = fmt.Sprintf("%0*v", 32, outputBin)     // 格式化输出32位,保留前置0
      fmt.Printf("【input】:%v       【output】:%v (%v)\n", input, output, outputBin)
}
```
这样在go test时就能与力扣官网的输入输出显示一致啦。望大佬采纳！
```bash
~/LeetCode-Go/leetcode/0190.Reverse-Bits$ go test
------------------------Leetcode Problem 190------------------------
【input】:00000010100101000001111010011100       【output】:964176192 (00111001011110000010100101000000)
【input】:11111111111111111111111111111101       【output】:3221225471 (10111111111111111111111111111111)



PASS
ok      github.com/halfrost/LeetCode-Go/leetcode/0190.Reverse-Bits      0.164s
```